### PR TITLE
#45: fixed wrong mex reference in toastMesh/SysmatSparsityStructure

### DIFF
--- a/script/matlab/toast2/toastMesh.m
+++ b/script/matlab/toast2/toastMesh.m
@@ -701,7 +701,7 @@ classdef toastMesh < handle
             % See also:
             %         toastMesh, SYSMATCOMPONENT
            
-            smat = toastmex(uint32(93),obj.handle);
+            smat = toastmex(uint32(92),obj.handle);
             
         end
         


### PR DESCRIPTION
@FelixLucka: Can you try if this fixes #45? There is nothing to compile, just a single bug fix in a Matlab script.