### PR TITLE
#48 fixed wrong parameter index in mtElmat.cc: toastElement/Mat('BndPFF ...)

### DIFF
--- a/src/matlab2/mtElement.cc
+++ b/src/matlab2/mtElement.cc
@@ -309,8 +309,10 @@ void MatlabToast::ElMat (int nlhs, mxArray *plhs[], int nrhs,
 
     } else if (!strcmp(cbuf, "BndPFF")) {
         int sd;
-        if (nrhs > nprm) sd =  (int)mxGetScalar(prhs[nprm+1]) - 1; // side index
-	else sd = -1;
+        if (nrhs > 4)
+	    sd =  (int)mxGetScalar(prhs[4]) - 1; // side index
+	else
+	    sd = -1;
 	elmat = mxCreateDoubleMatrix (nnd, nnd, mxREAL);
 	pr = mxGetPr(elmat);
 	RVector prm;


### PR DESCRIPTION
Fixes CTD on calling toastElement/Mat('BndPFF' ...)