### PR TITLE
#52 removed large mesh files from examples/matlab/gmsh

### DIFF
--- a/examples/matlab/gmsh/almi5.msh
+++ b/examples/matlab/gmsh/almi5.msh
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8468d9ce76334165d6a0990e64c140b15779f7c39832fbd5cc149b18fefc1a31
-size 163051625


### PR DESCRIPTION
Should avoid github quota problems.
May need to think about external hosting of those files (at least the lowres one.)