### PR TITLE
Add definition for float iszero

### DIFF
--- a/src/libmath/mathdef.h
+++ b/src/libmath/mathdef.h
@@ -120,6 +120,11 @@ inline bool iszero (std::complex<double> d)
     return d.real() == 0 && d.imag() == 0;
 }
 
+inline bool iszero (std::complex<float> d)
+{
+    return d.real() == 0 && d.imag() == 0;
+}
+
 inline bool operator> (const std::complex<double> &z1,
 		       const std::complex<double> &z2)
 {


### PR DESCRIPTION
Ubuntu 18.04 with `gcc version 7.4.0 (Ubuntu 7.4.0-1ubuntu1~18.04) ` fails build due to lack of `iszero` method for `std::complex<float>`. 

```
make toast
making all in /home/spowell/toastpp/src...
make[1]: Entering directory '/home/spowell/toastpp/src'
making all in libmath...
make[2]: Entering directory '/home/spowell/toastpp/gcc7.4.0_shared_smp/obj/libmath'
g++ -g -O2 -DTOAST_THREAD -Wno-deprecated  -I/home/spowell/toastpp -I/home/spowell/toastpp/include -I/home/spowell/toastpp/src/libtask -I/home/spowell/toastpp/numerics/SuperLU_5.0/SRC -I/home/spowell/toastpp/src/libmath -I/home/spowell/toastpp/src/libfe -I/home/spowell/toastpp/src/libdiffreg -I/home/spowell/toastpp/src/libfdot    -I/home/spowell/toastpp/src/libstoast -DFDOT  -I/include -fPIC -c /home/spowell/toastpp/src/libmath/crmatrix_cm.cc
In file included from /usr/include/c++/7/cmath:45:0,
                 from /usr/include/c++/7/math.h:36,
                 from /home/spowell/toastpp/src/libmath/mathlib.h:11,
                 from /home/spowell/toastpp/src/libmath/crmatrix_cm.cc:12:
/usr/include/math.h: In instantiation of ‘bool iszero(__T) [with __T = std::complex<float>]’:
/home/spowell/toastpp/src/libmath/crmatrix_imp.hpp:900:13:   required from ‘void TCompRowMatrix<MT>::SetRow(int, const TVector<VT>&) [with MT = std::complex<float>]’
/home/spowell/toastpp/src/libmath/crmatrix_cm.cc:284:1:   required from here
/usr/include/math.h:757:16: error: no match for ‘operator==’ (operand types are ‘std::complex<float>’ and ‘int’)
   return __val == 0;
          ~~~~~~^~~~
```

This is fixed by adding an appropriate definition to `mathdef.h` which I believe is where we put most of the changes when transitioning to `std::complex` a while back.

Not sure why this happens now but not previously, perhaps some extra template instantiation is happening that didn't before,  promotion rules have changed, or standard library modified. 