### PR TITLE
toastenv should check for extant file

### DIFF
--- a/toastenv.csh.in
+++ b/toastenv.csh.in
@@ -4,7 +4,7 @@
 if ( $?TOASTDIR ) then
 else
     echo "TOASTDIR environment variable not set!"
-    if ( -e mtoast_install.m ) then
+    if ( -e mtoast2_install.m ) then
 	setenv TOASTDIR $PWD
     endif
 endif

--- a/toastenv.sh.in
+++ b/toastenv.sh.in
@@ -3,7 +3,7 @@
 
 if test "x$TOASTDIR" = x; then
     echo "TOASTDIR environment variable not set!"
-    if test -f "mtoast_install.m" ; then
+    if test -f "mtoast2_install.m" ; then
 	export TOASTDIR=$PWD
     fi
 fi


### PR DESCRIPTION
We no longer ship `mtoast_install.m` so checking for this file as evidence of being in the toast directory will always fail.