### PR TITLE
Windows + Python build and wheel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,8 @@ toastpp
 toast_bin_darwin64.zip
 
 src/python/build
+src/python/dist
+src/python/PyToast.egg-info
 darwin64
 gcc_shared_smp
 src/doc

--- a/.gitignore
+++ b/.gitignore
@@ -65,5 +65,9 @@ win/**/x64/
 *.suo
 *.user
 *.sdf
+.vs/
 
 numerics/cuda/cusp_v0.2.0/cusp_v0.2.0
+
+numerics/Mesa*/windows/VC8/mesa/*/*.lib
+numerics/Mesa*/windows/VC8/mesa/*/x64/

--- a/numerics/Mesa-7.5.1/windows/VC8/mesa/gdi/gdi.vcxproj
+++ b/numerics/Mesa-7.5.1/windows/VC8/mesa/gdi/gdi.vcxproj
@@ -158,7 +158,7 @@ if exist ..\..\..\..\progs\demos copy "$(TargetDir)OPENGL32.DLL" ..\..\..\..\pro
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <Lib>
-      <OutputFile>""</OutputFile>
+      <OutputFile>$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName).lib</OutputFile>
     </Lib>
     <PostBuildEvent>
       <Command />

--- a/numerics/Mesa-7.5.1/windows/VC8/mesa/glu/glu.vcxproj
+++ b/numerics/Mesa-7.5.1/windows/VC8/mesa/glu/glu.vcxproj
@@ -124,7 +124,7 @@
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <Lib>
-      <OutputFile>""</OutputFile>
+      <OutputFile>$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName).lib</OutputFile>
     </Lib>
     <PostBuildEvent>
       <Command>

--- a/numerics/Mesa-7.5.1/windows/VC8/mesa/mesa/mesa.vcxproj
+++ b/numerics/Mesa-7.5.1/windows/VC8/mesa/mesa/mesa.vcxproj
@@ -124,7 +124,7 @@
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <Lib>
-      <OutputFile>""</OutputFile>
+      <OutputFile>$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName).lib</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
     </Lib>
   </ItemDefinitionGroup>

--- a/numerics/Mesa-7.5.1/windows/VC8/mesa/osmesa/osmesa.vcxproj
+++ b/numerics/Mesa-7.5.1/windows/VC8/mesa/osmesa/osmesa.vcxproj
@@ -126,13 +126,13 @@
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <Lib>
-      <OutputFile>""</OutputFile>
+      <OutputFile>$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName).lib</OutputFile>
     </Lib>
     <PostBuildEvent>
       <Command>if not exist ..\..\..\..\lib md ..\..\..\..\lib
-copy "$(TargetDir)OSMESA32.LIB" ..\..\..\..\lib
-copy "$(TargetDir)OSMESA32.DLL" ..\..\..\..\lib
-if exist ..\..\..\..\progs\demos copy "$(TargetDir)OSMESA32.DLL" ..\..\..\..\progs\demos
+copy "$(TargetDir)osmesa.lib" ..\..\..\..\lib
+copy "$(TargetDir)osmesa.dll" ..\..\..\..\lib
+if exist ..\..\..\..\progs\demos copy "$(TargetDir)osmesa.dll" ..\..\..\..\progs\demos
 </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>

--- a/numerics/Mesa-7.5.1/windows/VC8/mesa/osmesa/osmesa.vcxproj
+++ b/numerics/Mesa-7.5.1/windows/VC8/mesa/osmesa/osmesa.vcxproj
@@ -131,7 +131,7 @@
     <PostBuildEvent>
       <Command>if not exist ..\..\..\..\lib md ..\..\..\..\lib
 copy "$(TargetDir)osmesa.lib" ..\..\..\..\lib
-copy "$(TargetDir)osmesa.dll" ..\..\..\..\lib
+if exist "$(TargetDir)osmesa.dll" copy "$(TargetDir)osmesa.dll" ..\..\..\..\lib
 if exist ..\..\..\..\progs\demos copy "$(TargetDir)osmesa.dll" ..\..\..\..\progs\demos
 </Command>
     </PostBuildEvent>

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+import setuptools  # To enable bdist_wheel
 from distutils.core import setup, Extension
 import os
 import sys
@@ -31,15 +32,19 @@ module1 = Extension('toast.toastmod',
                                     toastdir+'/src/libstoast'],
                     libraries = ['libmath','libfe','libstoast'] if "nt" in os.name else ['math','fe','stoast'],
                     library_dirs = [toastdir+'/win/x64/Release/lib'] if "nt" in os.name else [toastdir+'/lib'],
-					runtime_library_dirs = None if "nt" in os.name else [toastdir+'/lib'],
+                    runtime_library_dirs = None if "nt" in os.name else [toastdir+'/lib'],
                     sources = ['toastmodule.cc'])
 
-setup (name = 'PyToast',
-       version = '120529',
-       description = 'Python TOAST extension',
-       author = 'Martin Schweiger',
-       url = 'http://www.toastplusplus.org',
-       ext_modules = [module1],
-       packages = ['toast']
+setup(
+    name = 'PyToast',
+    version = '120529',
+    description = 'Python TOAST extension',
+    author = 'Martin Schweiger',
+    url = 'http://www.toastplusplus.org',
+    ext_modules = [module1],
+    packages = ['toast'],
+    data_files = [('', [toastdir+'/win/x64/Release/bin/pthreadVC2.dll',
+                        toastdir+'/win/x64/Release/bin/libfe.dll',
+                        toastdir+'/win/x64/Release/bin/libmath.dll',
+                        toastdir+'/win/x64/Release/bin/libstoast.dll'])] if "nt" in os.name else []
 )
-


### PR DESCRIPTION
I was getting errors with `msbuild` related to not being able to parse the `OutputFile`. I have no idea how the AppVeyor CI manages to build because its log and my log have identical msbuild versions. AppVeyor must have some magic environment variables that I'm missing.

With these changes, I can build, but there needs to be a specific order of operations:

1. Open the win\vs2015\toast.sln (I use VS2017 but tell it not to udpate)
2. Change the Config to Release and Platform to x64
3. Rt-click and build each of the Mesa\ targets. These need to be built before the top-level projects.
4. Use the Build menu to Build Solution, or build only the targets you want as in step 3.

Then to generate the Python wheel, from a VS2015 or VS2017 native tools command prompt:

```
conda activate <my_env_with_numpy>
cd src\python
python setup.py build --build-base=../../win/x64/Release/python
python setup.py bdist_wheel
```

The wheel ends up in src\python\dist

It can be installed with `pip install <path\to\PyToast....whl>`.

This puts the requisite dll files into the conda env's top-leve `site-packages` directory, which is not ideal, but I couldn't figure out how to get the dlls into the wheel with `package_data`, so I used `data_files`.